### PR TITLE
Fixed issue 25

### DIFF
--- a/Server/Protocol.cs
+++ b/Server/Protocol.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using Valk.Networking;
 
 public class Protocol : IDisposable
 {
@@ -31,9 +30,6 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 bufferSize += (sizeof(char) * ((string)value).Length);
-
-            if (type == typeof(byte) || type.IsEnum)
-                bufferSize += sizeof(byte);
         }
 
         InitWriter(bufferSize);
@@ -53,12 +49,6 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 writer.Write((string)value);
-
-            if (type == typeof(byte))
-                writer.Write((byte)value);
-
-            if (type.IsEnum)
-                writer.Write((byte)(int)value); // before finding something better
         }
         return buffer;
     }

--- a/Server/Protocol.cs
+++ b/Server/Protocol.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Valk.Networking;
 
 public class Protocol : IDisposable
 {
@@ -30,6 +31,9 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 bufferSize += (sizeof(char) * ((string)value).Length);
+
+            if (type == typeof(byte) || type.IsEnum)
+                bufferSize += sizeof(byte);
         }
 
         InitWriter(bufferSize);
@@ -49,6 +53,12 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 writer.Write((string)value);
+
+            if (type == typeof(byte))
+                writer.Write((byte)value);
+
+            if (type.IsEnum)
+                writer.Write((byte)(int)value); // before finding something better
         }
         return buffer;
     }

--- a/Server/Protocol.cs
+++ b/Server/Protocol.cs
@@ -31,11 +31,7 @@ public class Protocol : IDisposable
             if (type == typeof(string))
                 bufferSize += (sizeof(char) * ((string)value).Length);
 
-<<<<<<< HEAD
             if (type == typeof(byte) || type.IsEnum)
-=======
-            if (type == typeof(Valk.Networking.ErrorType))
->>>>>>> aebe5890a4ae38df6600cca8d6b441198077db01
                 bufferSize += sizeof(byte);
         }
 
@@ -57,16 +53,11 @@ public class Protocol : IDisposable
             if (type == typeof(string))
                 writer.Write((string)value);
 
-<<<<<<< HEAD
             if (type == typeof(byte))
                 writer.Write((byte)value);
 
             if (type.IsEnum)
                  writer.Write((byte)(int)value);
-=======
-            if (type == typeof(Valk.Networking.ErrorType))
-                writer.Write((byte)value); // Casted as byte for consistency with Packet.cs
->>>>>>> aebe5890a4ae38df6600cca8d6b441198077db01
         }
         return buffer;
     }

--- a/Server/Protocol.cs
+++ b/Server/Protocol.cs
@@ -30,6 +30,9 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 bufferSize += (sizeof(char) * ((string)value).Length);
+
+            if (type == typeof(byte) || type.IsEnum)
+                bufferSize += sizeof(byte);
         }
 
         InitWriter(bufferSize);
@@ -49,6 +52,12 @@ public class Protocol : IDisposable
 
             if (type == typeof(string))
                 writer.Write((string)value);
+
+            if (type == typeof(byte))
+                writer.Write((byte)value);
+
+            if (type.IsEnum)
+                 writer.Write((byte)(int)value);
         }
         return buffer;
     }


### PR DESCRIPTION
### Changes
- Added `Valk.Networking.ErrorType` to serializer in Protocol.cs
- Casted ErrorType to byte for consistancy with Packet.cs 
https://github.com/valkyrienyanko/Unity-MMORPG-Boilerplate/blob/cc62c7fc37515e1ca364380c80c6291fa1a68d1f/Server/Packet.cs#L36

### Tests
- Tried to log into unexistent account
- Tried to log with wrong password
- Tried to register already existing account

In every instances, the ErrorType is now correctly serialized and passed down to the client.

See issue https://github.com/valkyrienyanko/Unity-MMORPG-Boilerplate/issues/25 for further references