### PR TITLE
Refactored server commands

### DIFF
--- a/Server/Commands.cs
+++ b/Server/Commands.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Valk.Networking {
+    static class Commands {
+        private static string[] commands = {
+            "help",
+            "exit"
+        };
+
+        public static void Help(string[] args){
+            Logger.Log($"Commands:\n - {String.Join("\n - ", commands)}");
+        }
+
+        public static void Exit(string[] args){
+            var server = Program.Server;
+
+            Logger.Log("Exiting..");
+            server.Stop();
+            Environment.Exit(0);
+        }
+    }
+}

--- a/Server/Commands.cs
+++ b/Server/Commands.cs
@@ -1,22 +1,7 @@
-using System;
-
 namespace Valk.Networking {
-    static class Commands {
-        private static string[] commands = {
-            "help",
-            "exit"
-        };
-
-        public static void Help(string[] args){
-            Logger.Log($"Commands:\n - {String.Join("\n - ", commands)}");
-        }
-
-        public static void Exit(string[] args){
-            var server = Program.Server;
-
-            Logger.Log("Exiting..");
-            server.Stop();
-            Environment.Exit(0);
+    public abstract class Commands {
+        public virtual void Run(string[] args){
+            Logger.Log("Unimplemented command.");
         }
     }
 }

--- a/Server/Commands/Exit.cs
+++ b/Server/Commands/Exit.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Valk.Networking {
+    public class Exit : Commands {
+        public override void Run(string[] args){
+            var server = Program.Server;
+
+            Logger.Log("Exiting..");
+            server.Stop();
+            Environment.Exit(0);
+        }
+    }
+}

--- a/Server/Commands/Help.cs
+++ b/Server/Commands/Help.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Linq;
+
+namespace Valk.Networking {
+    public class Help : Commands {
+        // Loads available commands into array at runtime
+        protected static string[] commands = typeof(Commands).Assembly.GetTypes()
+                        .Where(x => typeof(Commands).IsAssignableFrom(x) && !x.IsAbstract)
+                        .Select(Activator.CreateInstance).Cast<Commands>()
+                        .Aggregate("", (str,x) => str + x.GetType().Name.ToLower() + " ")
+                        .Split(' ').Where(x => !string.IsNullOrEmpty(x)).ToArray();
+        public override void Run(string[] args){
+            Logger.Log($"Commands:\n - {String.Join("\n - ", commands)}");
+        }
+    }
+}

--- a/Server/InputHandler.cs
+++ b/Server/InputHandler.cs
@@ -9,9 +9,9 @@ namespace Valk.Networking
         private List<string> memory;
         private int memoryIndex = 0;
 
-        private string[] commands = {
-            "help",
-            "exit"
+        private Dictionary<string, Action<string[]>> commands = new Dictionary<string, Action<string[]>> {
+            {"help", Commands.Help},
+            {"exit", Commands.Exit}
         };
 
         private ConsoleKey[] exclude = {
@@ -79,20 +79,11 @@ namespace Valk.Networking
         {
             string cmd = input.ToLower().Split(' ')[0];
             string[] args = input.ToLower().Split(' ').Skip(1).ToArray();
-
-            var server = Program.Server;
-
-            if (cmd.Equals("help"))
-            {
-                Logger.Log($"Commands:\n - {String.Join("\n - ", commands)}");
-            } else if (cmd.Equals("exit"))
-            {
-                Logger.Log("Exiting..");
-                server.Stop();
-                Environment.Exit(0);
-            } else {
+            
+            if (commands.ContainsKey(cmd))
+                commands[cmd].Invoke(args);
+            else
                 Logger.Log($"Unknown Command: '{cmd}'");
-            }
         }
     }
 }

--- a/Server/InputHandler.cs
+++ b/Server/InputHandler.cs
@@ -9,11 +9,11 @@ namespace Valk.Networking
         private List<string> memory;
         private int memoryIndex = 0;
 
-        private Dictionary<string, Action<string[]>> commands = new Dictionary<string, Action<string[]>> {
-            {"help", Commands.Help},
-            {"exit", Commands.Exit}
-        };
-
+        // Loads commands into dictionary at runtime
+        private Dictionary<string, Commands> commands = typeof(Commands).Assembly.GetTypes()
+                                                        .Where(x => typeof(Commands).IsAssignableFrom(x) && !x.IsAbstract)
+                                                        .Select(Activator.CreateInstance).Cast<Commands>()
+                                                        .ToDictionary(x => x.GetType().Name.ToLower(), x => x);
         private ConsoleKey[] exclude = {
             ConsoleKey.LeftArrow,
             ConsoleKey.RightArrow,
@@ -81,7 +81,7 @@ namespace Valk.Networking
             string[] args = input.ToLower().Split(' ').Skip(1).ToArray();
             
             if (commands.ContainsKey(cmd))
-                commands[cmd].Invoke(args);
+                commands[cmd].Run(args);
             else
                 Logger.Log($"Unknown Command: '{cmd}'");
         }


### PR DESCRIPTION
### Changes
- Separated commands declaration from input handling.
- Created static class `Commands`.
- Migrated commands code from `InputHandling` to `Commands`.
- Changed access complexity of commands from O(n) to O(1) with dictionary.

### Tests
- Tried to call command `help` with success.
- Tried to call command `exit` with success.
- Tried to call non existent command with success (ie. no crash and properly logged message).
